### PR TITLE
better n5 support, tooling for changing coordinate metadata of an entire multiscale group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -414,6 +414,70 @@ files = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.4.0"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "coverage-7.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36b0ea8ab20d6a7564e89cb6135920bc9188fb5f1f7152e94e8300b7b189441a"},
+    {file = "coverage-7.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0676cd0ba581e514b7f726495ea75aba3eb20899d824636c6f59b0ed2f88c471"},
+    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0ca5c71a5a1765a0f8f88022c52b6b8be740e512980362f7fdbb03725a0d6b9"},
+    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7c97726520f784239f6c62506bc70e48d01ae71e9da128259d61ca5e9788516"},
+    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:815ac2d0f3398a14286dc2cea223a6f338109f9ecf39a71160cd1628786bc6f5"},
+    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:80b5ee39b7f0131ebec7968baa9b2309eddb35b8403d1869e08f024efd883566"},
+    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5b2ccb7548a0b65974860a78c9ffe1173cfb5877460e5a229238d985565574ae"},
+    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:995ea5c48c4ebfd898eacb098164b3cc826ba273b3049e4a889658548e321b43"},
+    {file = "coverage-7.4.0-cp310-cp310-win32.whl", hash = "sha256:79287fd95585ed36e83182794a57a46aeae0b64ca53929d1176db56aacc83451"},
+    {file = "coverage-7.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:5b14b4f8760006bfdb6e08667af7bc2d8d9bfdb648351915315ea17645347137"},
+    {file = "coverage-7.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:04387a4a6ecb330c1878907ce0dc04078ea72a869263e53c72a1ba5bbdf380ca"},
+    {file = "coverage-7.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ea81d8f9691bb53f4fb4db603203029643caffc82bf998ab5b59ca05560f4c06"},
+    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74775198b702868ec2d058cb92720a3c5a9177296f75bd97317c787daf711505"},
+    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:76f03940f9973bfaee8cfba70ac991825611b9aac047e5c80d499a44079ec0bc"},
+    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:485e9f897cf4856a65a57c7f6ea3dc0d4e6c076c87311d4bc003f82cfe199d25"},
+    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6ae8c9d301207e6856865867d762a4b6fd379c714fcc0607a84b92ee63feff70"},
+    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:bf477c355274a72435ceb140dc42de0dc1e1e0bf6e97195be30487d8eaaf1a09"},
+    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:83c2dda2666fe32332f8e87481eed056c8b4d163fe18ecc690b02802d36a4d26"},
+    {file = "coverage-7.4.0-cp311-cp311-win32.whl", hash = "sha256:697d1317e5290a313ef0d369650cfee1a114abb6021fa239ca12b4849ebbd614"},
+    {file = "coverage-7.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:26776ff6c711d9d835557ee453082025d871e30b3fd6c27fcef14733f67f0590"},
+    {file = "coverage-7.4.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:13eaf476ec3e883fe3e5fe3707caeb88268a06284484a3daf8250259ef1ba143"},
+    {file = "coverage-7.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846f52f46e212affb5bcf131c952fb4075b55aae6b61adc9856222df89cbe3e2"},
+    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26f66da8695719ccf90e794ed567a1549bb2644a706b41e9f6eae6816b398c4a"},
+    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:164fdcc3246c69a6526a59b744b62e303039a81e42cfbbdc171c91a8cc2f9446"},
+    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:316543f71025a6565677d84bc4df2114e9b6a615aa39fb165d697dba06a54af9"},
+    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bb1de682da0b824411e00a0d4da5a784ec6496b6850fdf8c865c1d68c0e318dd"},
+    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:0e8d06778e8fbffccfe96331a3946237f87b1e1d359d7fbe8b06b96c95a5407a"},
+    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a56de34db7b7ff77056a37aedded01b2b98b508227d2d0979d373a9b5d353daa"},
+    {file = "coverage-7.4.0-cp312-cp312-win32.whl", hash = "sha256:51456e6fa099a8d9d91497202d9563a320513fcf59f33991b0661a4a6f2ad450"},
+    {file = "coverage-7.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd3c1e4cb2ff0083758f09be0f77402e1bdf704adb7f89108007300a6da587d0"},
+    {file = "coverage-7.4.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e9d1bf53c4c8de58d22e0e956a79a5b37f754ed1ffdbf1a260d9dcfa2d8a325e"},
+    {file = "coverage-7.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:109f5985182b6b81fe33323ab4707011875198c41964f014579cf82cebf2bb85"},
+    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cc9d4bc55de8003663ec94c2f215d12d42ceea128da8f0f4036235a119c88ac"},
+    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc6d65b21c219ec2072c1293c505cf36e4e913a3f936d80028993dd73c7906b1"},
+    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a10a4920def78bbfff4eff8a05c51be03e42f1c3735be42d851f199144897ba"},
+    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b8e99f06160602bc64da35158bb76c73522a4010f0649be44a4e167ff8555952"},
+    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:7d360587e64d006402b7116623cebf9d48893329ef035278969fa3bbf75b697e"},
+    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:29f3abe810930311c0b5d1a7140f6395369c3db1be68345638c33eec07535105"},
+    {file = "coverage-7.4.0-cp38-cp38-win32.whl", hash = "sha256:5040148f4ec43644702e7b16ca864c5314ccb8ee0751ef617d49aa0e2d6bf4f2"},
+    {file = "coverage-7.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:9864463c1c2f9cb3b5db2cf1ff475eed2f0b4285c2aaf4d357b69959941aa555"},
+    {file = "coverage-7.4.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:936d38794044b26c99d3dd004d8af0035ac535b92090f7f2bb5aa9c8e2f5cd42"},
+    {file = "coverage-7.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:799c8f873794a08cdf216aa5d0531c6a3747793b70c53f70e98259720a6fe2d7"},
+    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7defbb9737274023e2d7af02cac77043c86ce88a907c58f42b580a97d5bcca9"},
+    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1526d265743fb49363974b7aa8d5899ff64ee07df47dd8d3e37dcc0818f09ed"},
+    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf635a52fc1ea401baf88843ae8708591aa4adff875e5c23220de43b1ccf575c"},
+    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:756ded44f47f330666843b5781be126ab57bb57c22adbb07d83f6b519783b870"},
+    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0eb3c2f32dabe3a4aaf6441dde94f35687224dfd7eb2a7f47f3fd9428e421058"},
+    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bfd5db349d15c08311702611f3dccbef4b4e2ec148fcc636cf8739519b4a5c0f"},
+    {file = "coverage-7.4.0-cp39-cp39-win32.whl", hash = "sha256:53d7d9158ee03956e0eadac38dfa1ec8068431ef8058fe6447043db1fb40d932"},
+    {file = "coverage-7.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:cfd2a8b6b0d8e66e944d47cdec2f47c48fef2ba2f2dff5a9a75757f64172857e"},
+    {file = "coverage-7.4.0-pp38.pp39.pp310-none-any.whl", hash = "sha256:c530833afc4707fe48524a44844493f36d8727f04dcce91fb978c414a8556cc6"},
+    {file = "coverage-7.4.0.tar.gz", hash = "sha256:707c0f58cb1712b8809ece32b68996ee1e609f71bd14615bd8f87a1293cb610e"},
+]
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
@@ -2031,4 +2095,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8b735a59febb674109ab26c25f3bb6cc57ffce7484583304e6289c2b19749fa4"
+content-hash = "704b44a6a8ec47f29a0631d35a4af28b2bd1a73e52df61bcdcf2a7ff642af24e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,18 +13,19 @@ s3fs = "^2023.10.0"
 rich = "^13.7.0"
 
 
+
 [tool.poetry.group.docs.dependencies]
 mkdocs-material = "^9.4.2"
 mkdocstrings = {extras = ["python"], version = "^0.23.0"}
 
-
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"
-
+coverage = "^7.4.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.7.1"
 pytest-examples = "^0.0.10"
+
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cellmap-schemas"
-version = "0.1.4"
+version = "0.3.0"
 description = "Schemas for data used by the Cellmap project team at Janelia Research Campus."
 authors = ["Davis Vann Bennett <davis.v.bennett@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cellmap-schemas"
-version = "0.4.0"
+version = "0.3.0"
 description = "Schemas for data used by the Cellmap project team at Janelia Research Campus."
 authors = ["Davis Vann Bennett <davis.v.bennett@gmail.com>"]
 readme = "README.md"

--- a/src/cellmap_schemas/base.py
+++ b/src/cellmap_schemas/base.py
@@ -1,0 +1,38 @@
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
+
+
+def structure_array_equal(spec_a: ArraySpec, spec_b: ArraySpec) -> bool:
+    return spec_a.model_dump(exclude=["attributes"]) == spec_b.model_dump(exclude=["attributes"])
+
+
+def structure_group_equal(spec_a: GroupSpec, spec_b: GroupSpec) -> bool:
+    keys_equal = spec_a.members.keys() == spec_b.members.keys()
+    if keys_equal:
+        for member_a, member_b in zip(spec_a.members.values(), spec_b.members.values()):
+            if isinstance(member_a, ArraySpec):
+                member_eq = structure_array_equal(member_a, member_b)
+            else:
+                member_eq = structure_group_equal(member_a, member_b)
+            if member_eq is False:
+                return False
+        return True
+    else:
+        return False
+
+
+def structure_equal(spec_a: ArraySpec | GroupSpec, spec_b: ArraySpec | GroupSpec) -> bool:
+    """
+    Check that two GroupSpec / ArraySpec instances are identical up to their attributes
+    """
+    if not (
+        isinstance(spec_a, (ArraySpec, GroupSpec)) and isinstance(spec_b, (ArraySpec, GroupSpec))
+    ):
+        raise TypeError(
+            f"Cannot apply this function to objects with types ({type(spec_a)}, {type(spec_b)})"
+        )
+    if isinstance(spec_a, ArraySpec) and isinstance(spec_b, ArraySpec):
+        return structure_array_equal(spec_a, spec_b)
+    elif isinstance(spec_a, GroupSpec) and isinstance(spec_b, GroupSpec):
+        return structure_group_equal(spec_a, spec_b)
+    else:
+        return False

--- a/src/cellmap_schemas/multiscale/neuroglancer_n5.py
+++ b/src/cellmap_schemas/multiscale/neuroglancer_n5.py
@@ -6,8 +6,9 @@ for details on what Neuroglancer expects when it reads N5 data.
 
 from typing import Annotated, Sequence
 from pydantic import BaseModel, PositiveInt, model_validator, AfterValidator
-from pydantic_zarr.v2 import GroupSpec, ArraySpec
-import zarr
+from pydantic_zarr.v2 import ArraySpec
+
+from cellmap_schemas.n5_wrap import N5GroupSpec
 
 
 class PixelResolution(BaseModel):
@@ -177,7 +178,7 @@ def check_scale_level_name(name: str) -> bool:
     return valid
 
 
-class Group(GroupSpec):
+class Group(N5GroupSpec):
     """
     A `GroupSpec` representing the structure of a N5 group with
     neuroglancer-compatible structure and metadata.
@@ -215,31 +216,3 @@ class Group(GroupSpec):
                 )
 
         return self
-
-    @classmethod
-    def from_zarr(cls, node: zarr.Group):
-        """
-        Create an instance of `Group` from a Zarr group. This method will
-        raise an exception if the Zarr group is not backed by one of the N5-compatible
-        stores (`zarr.N5Store`, `zarr.N5FSStore`).
-
-        Parameters
-        ----------
-
-        node: zarr.Group
-                A Zarr group. Should be backed by N5-formatted storage.
-
-        Returns
-        -------
-
-        An instance of `Group`.
-        """
-        if not isinstance(node.store, (zarr.N5FSStore, zarr.N5Store)):
-            raise ValueError(
-                f"{cls.__name__} must be using an N5-compatible storage backend, "
-                f"namely zarr.N5FSStore or zarr.N5Store. Got {node.store.__class__} "
-                "instead"
-            )
-        else:
-            base = GroupSpec.from_zarr(node).model_dump()
-            return cls(**base)

--- a/src/cellmap_schemas/n5_wrap.py
+++ b/src/cellmap_schemas/n5_wrap.py
@@ -1,0 +1,340 @@
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
+from typing import overload, Union
+
+from zarr.core import Array
+from zarr.storage import BaseStore
+import zarr
+
+from cellmap_schemas.base import structure_equal
+
+
+@overload
+def n5_spec_wrapper(spec: ArraySpec) -> ArraySpec:
+    ...
+
+
+@overload
+def n5_spec_wrapper(spec: GroupSpec) -> GroupSpec:
+    ...
+
+
+def n5_spec_wrapper(spec: Union[GroupSpec, ArraySpec]) -> Union[GroupSpec, ArraySpec]:
+    """
+    Convert an instance of GroupSpec into one that can be materialized
+    via `zarr.N5FSStore`. This requires changing array compressor metadata
+    and checking that the `dimension_separator` attribute is compatible wih N5FSStore.
+
+    Parameters
+    ----------
+    spec: Union[GroupSpec, ArraySpec]
+        The spec to transform. An n5-compatible version of this spec will be generated.
+
+    Returns
+    -------
+    Union[GroupSpec, ArraySpec]
+    """
+    if isinstance(spec, ArraySpec):
+        return n5_array_wrapper(spec)
+    else:
+        return n5_group_wrapper(spec)
+
+
+def n5_group_wrapper(spec: GroupSpec) -> GroupSpec:
+    """
+    Transform a GroupSpec to make it compatible with N5FSStore. This function
+    recursively applies itself `n5_spec_wrapper` on its members to produce an
+    n5-compatible spec.
+
+    Parameters
+    ----------
+    spec: GroupSpec
+        The spec to transform. Only array descendants of this spec will actually be
+        altered after the transformation.
+
+    Returns
+    -------
+    GroupSpec
+    """
+    new_members = {}
+    for key, member in spec.members.items():
+        if hasattr(member, "shape"):
+            new_members[key] = n5_array_wrapper(member)
+        else:
+            new_members[key] = n5_group_wrapper(member)
+
+    return spec.__class__(attributes=spec.attributes, members=new_members)
+
+
+def n5_array_wrapper(spec: ArraySpec) -> ArraySpec:
+    """
+    Transform an ArraySpec into one that is compatible with `zarr.N5FSStore`. This function
+     ensures that the `dimension_separator` of the ArraySpec is ".".
+
+    Parameters
+    ----------
+    spec: ArraySpec
+        ArraySpec instance to be transformed.
+
+    Returns
+    -------
+    ArraySpec
+    """
+    return spec.__class__(**(spec.model_dump() | dict(dimension_separator=".")))
+
+
+def n5_array_unwrapper(spec: ArraySpec) -> ArraySpec:
+    """
+    Transform an ArraySpec from one parsed from an array stored in N5. This function
+    applies two changes: First, the `dimension_separator` of the ArraySpec is set to
+    "/", and second, the `compressor` field has some N5-specific wrapping removed.
+
+    Parameters
+    ----------
+    spec: ArraySpec
+        The ArraySpec to be transformed.
+
+    Returns
+    -------
+    ArraySpec
+    """
+    new_metadata = dict(compressor=spec.compressor["compressor_config"], dimension_separator="/")
+    return spec.__class__(**(spec.model_dump() | new_metadata))
+
+
+def n5_group_unwrapper(spec: GroupSpec) -> GroupSpec:
+    """
+    Transform a GroupSpec to remove the N5-specific attributes. Used when generating
+    GroupSpec instances from Zarr groups that are stored using `zarr.N5FSStore`.
+    This function will be applied recursively to subgroups; subarrays will be
+    transformed with `n5_array_unwrapper`.
+
+    Parameters
+    ----------
+    spec: GroupSpec
+        The spec to be transformed.
+
+    Returns
+    -------
+    GroupSpec
+    """
+    new_members = {}
+    for key, member in spec.members.items():
+        if isinstance(member, ArraySpec):
+            new_members[key] = n5_array_unwrapper(member)
+        else:
+            new_members[key] = n5_group_unwrapper(member)
+    return spec.__class__(attributes=spec.attributes, members=new_members)
+
+
+@overload
+def n5_spec_unwrapper(spec: ArraySpec) -> ArraySpec:
+    ...
+
+
+@overload
+def n5_spec_unwrapper(spec: GroupSpec) -> GroupSpec:
+    ...
+
+
+def n5_spec_unwrapper(spec: Union[GroupSpec, ArraySpec]) -> Union[GroupSpec, ArraySpec]:
+    """
+    Transform a GroupSpec or ArraySpec to remove the N5-specific attributes.
+    Used when generating GroupSpec or ArraySpec instances from Zarr groups that are
+    stored using N5FSStore. If the input is an instance of GroupSpec, this
+    function will be applied recursively to subgroups; subarrays will be transformed
+    via `n5_array_unwrapper`. If the input is an ArraySpec, it will be transformed with
+    `n5_array_unwrapper`.
+
+    Parameters
+    ----------
+    spec: Union[GroupSpec, ArraySpec]
+        The spec to be transformed.
+
+    Returns
+    -------
+    Union[GroupSpec, ArraySpec]
+    """
+    if isinstance(spec, ArraySpec):
+        return n5_array_unwrapper(spec)
+    else:
+        return n5_group_unwrapper(spec)
+
+
+class N5ArraySpec(ArraySpec):
+    def to_zarr(self, store: BaseStore, path: str, overwrite: bool = False) -> zarr.Array:
+        """
+        Create a Zarr array from an `N5ArraySpec`.
+
+        Parameters
+        ----------
+
+        store: zarr.N5FSStore
+            The storage backend to use for storage. Must be an instance of `zarr.N5FSStore`.
+        path: str
+            The location within the storage backend for the Zarr array.
+        overwrite: bool
+            If `True`, any Zarr arrays or groups at `path` will be removed.
+            If `False` (default), Zarr arrays or groups at `path` will result in an error.
+
+        Returns
+        -------
+
+        zarr.Array
+        """
+        wrapped = ArraySpec(**n5_array_wrapper(self).model_dump())
+        return wrapped.to_zarr(store, path, overwrite)
+
+    @classmethod
+    def from_zarr(cls, zarray: Array):
+        """
+        Create an instance of this class from a Zarr array. This method will
+        raise an exception if the Zarr group is not backed by `zarr.N5FSStore`.
+
+        Parameters
+        ----------
+
+        node: zarr.Array
+            A Zarr array. The `store` attribute of this array must be an instance of `N5FSStore`.
+
+        Returns
+        -------
+
+        An instance of `N5Array`.
+        """
+
+        result = n5_array_unwrapper(super().from_zarr(zarray))
+        return cls(**result.model_dump())
+
+
+class N5GroupSpec(GroupSpec):
+    def to_zarr(self, store: zarr.N5FSStore, path: str, overwrite: bool = False) -> zarr.Group:
+        """
+        Create a Zarr group from an `N5GroupSpec`.
+
+        Parameters
+        ----------
+
+        store: zarr.N5FSStore
+            The storage backend to use for storage. Must be an instance of `zarr.N5FSStore`.
+        path: str
+            The location within the storage backend for the Zarr Group.
+        overwrite: bool
+            If `True`, any Zarr arrays or groups at `path` will be removed.
+            If `False` (default), Zarr arrays or groups at `path` will result in an error.
+
+        Returns
+        -------
+
+        zarr.Group
+        """
+        if not isinstance(store, zarr.N5FSStore):
+            msg = (
+                f"Instances of {self.__class__} must use an N5-compatible storage backend, "
+                f"namely `zarr.N5FSStore`. Got {store.__class__} instead"
+            )
+            raise TypeError(msg)
+        wrapped = GroupSpec(**n5_group_wrapper(self).model_dump())
+        return wrapped.to_zarr(store, path, overwrite=overwrite)
+
+    @classmethod
+    def from_zarr(cls, node: zarr.Group) -> "N5GroupSpec":
+        """
+        Create an instance of this class from a Zarr group. This method will
+        raise an exception if the Zarr group is not backed by `zarr.N5FSStore`.
+
+        Parameters
+        ----------
+
+        node: zarr.Group
+            A Zarr group. The `store` attribute of this group must be an instance of `N5FSStore`.
+
+        Returns
+        -------
+
+        An instance of `N5Group`.
+        """
+        if not isinstance(node.store, zarr.N5FSStore):
+            msg = (
+                f"Instances of {cls.__name__} must be use an N5-compatible storage backend, "
+                f"namely `zarr.N5FSStore`. Got {node.store.__class__} instead"
+            )
+            raise TypeError(msg)
+        else:
+            base = n5_group_unwrapper(super().from_zarr(node)).model_dump()
+            return cls(**base)
+
+
+@overload
+def from_zarr(element: zarr.Group) -> N5GroupSpec:
+    ...
+
+
+@overload
+def from_zarr(element: zarr.Array) -> N5ArraySpec:
+    ...
+
+
+def from_zarr(element: Union[zarr.Array, zarr.Group]) -> Union[N5ArraySpec, N5GroupSpec]:
+    """
+    Recursively parse a Zarr group or Zarr array into an untyped ArraySpec or GroupSpec.
+
+    Parameters
+    ---------
+    element : Union[zarr.Array, zarr.Group]
+
+    Returns
+    -------
+    An instance of GroupSpec or ArraySpec that represents the
+    structure of the zarr group or array.
+    """
+
+    if isinstance(element, zarr.Array):
+        result = N5ArraySpec.from_zarr(element)
+    elif isinstance(element, zarr.Group):
+        members = {}
+        for name, member in element.items():
+            if isinstance(member, zarr.Array):
+                _item = N5ArraySpec.from_zarr(member)
+            elif isinstance(member, zarr.Group):
+                _item = N5GroupSpec.from_zarr(member)
+            else:
+                msg = (
+                    f"Unparseable object encountered: {type(member)}. Expected "
+                    "zarr.Array or zarr.Group.",
+                )
+                raise ValueError(msg)
+            members[name] = _item
+
+        result = N5GroupSpec(attributes=element.attrs.asdict(), members=members)
+        return result
+    else:
+        msg = (
+            f"Object of type {type(element)} cannot be processed by this function. "
+            "This function can only parse zarr.Group or zarr.Array"
+        )
+        raise TypeError(msg)
+    return result
+
+
+def update_n5_attrs(node: Union[zarr.Group, zarr.Array], new_spec: N5GroupSpec):
+    """
+    Update the attributes of an N5-flavored zarr group and its contents
+    """
+
+    # first check that the two groups are structurally compatible
+    if not structure_equal(from_zarr(node), new_spec):
+        msg = (
+            f"The node {node} is not structurally equivalent with the new spec. "
+            "This means that some of the non-attributes properties differ between the existing and new spec. "
+            "This function may only be applied when the the second argument defines a zarr group that is structurally "
+            "identical to the existing zarr group."
+        )
+        raise ValueError(msg)
+
+    node.attrs.update(new_spec.attributes.model_dump())
+
+    if isinstance(node, zarr.Group):
+        for name, member in new_spec.members.items():
+            update_n5_attrs(node[name], member)
+
+    return node

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,34 @@
+from cellmap_schemas.base import structure_equal
+
+
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
+
+
+def test_structure_equal():
+    array_a = ArraySpec(
+        shape=(10, 10),
+        chunks=(10, 10),
+        dtype="uint8",
+        compressor=None,
+        filters=None,
+        fill_value=0,
+        attributes={},
+    )
+    array_b = array_a.model_copy(deep=True, update={"shape": (20, 20)})
+
+    assert structure_equal(array_a, array_a)
+    assert not structure_equal(array_a, array_b)
+
+    group_a = GroupSpec(attributes={"foo": 10}, members={"array": array_a})
+    group_b = group_a.model_copy(deep=True)
+    assert structure_equal(group_a, group_b)
+
+    group_c = group_a.model_copy(deep=True, update={"attributes": {"foo": 1000}})
+    assert group_a != group_c
+    assert structure_equal(group_a, group_c)
+
+    group_d = group_a.model_copy(deep=True, update={"members": {"array_new": array_a}})
+    assert not structure_equal(group_a, group_d)
+
+    group_e = group_a.model_copy(deep=True, update={"members": {"array": array_b}})
+    assert not structure_equal(group_a, group_e)

--- a/tests/test_multiscale/test_cosem.py
+++ b/tests/test_multiscale/test_cosem.py
@@ -1,6 +1,7 @@
 from functools import reduce
 import operator
 from typing import Literal, Optional, Tuple
+import numpy as np
 from pydantic import ValidationError
 import pytest
 from cellmap_schemas.multiscale.cosem import (
@@ -11,6 +12,7 @@ from cellmap_schemas.multiscale.cosem import (
     Group,
     Array,
     ScaleMetadata,
+    change_coordinates,
 )
 from cellmap_schemas.multiscale.neuroglancer_n5 import PixelResolution
 
@@ -95,6 +97,89 @@ def test_multiscale_array_consistent_units():
         ArrayMetadata.model_validate(data)
 
 
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_array_meta_from_transform(order: Literal["C", "F"]):
+    tx = STTransform(
+        order=order, scale=(3, 2, 1), translate=(1,) * 3, units=("nm",) * 3, axes=("z", "y", "x")
+    )
+    if order == "C":
+        expected = ArrayMetadata(
+            pixelResolution=PixelResolution(unit=tx.units[0], dimensions=tx.scale[::-1]),
+            transform=tx,
+        )
+    else:
+        expected = ArrayMetadata(
+            pixelResolution=PixelResolution(unit=tx.units[-1], dimensions=tx.scale), transform=tx
+        )
+    assert ArrayMetadata.from_transform(tx) == expected
+
+
+@pytest.mark.parametrize("name", [None, "foo"])
+@pytest.mark.parametrize("order", ["C", "F"])
+@pytest.mark.parametrize("scale", [(1, 2, 3), (2, 4, 6)])
+@pytest.mark.parametrize("axes", [("a", "b", "c"), ("z", "y", "x")])
+def test_multiscale_meta_from_transforms(
+    name: Optional[str], order: Literal["C", "F"], scale: Tuple[int, ...], axes: Tuple[str, ...]
+):
+    transforms = {
+        "s0": STTransform(
+            order=order, scale=scale, translate=(1,) * 3, units=("nm",) * 3, axes=axes
+        ),
+        "s1": STTransform(
+            order=order,
+            scale=tuple(2 * s for s in scale),
+            translate=(1.5,) * 3,
+            units=("nm",) * 3,
+            axes=axes,
+        ),
+    }
+
+    expected = MultiscaleMetadata(
+        name=name,
+        datasets=[ScaleMetadata(path=key, transform=tx) for key, tx in transforms.items()],
+    )
+    assert MultiscaleMetadata.from_transforms(transforms, name=name) == expected
+
+
+@pytest.mark.parametrize("name", [None, "bar"])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_groupmetadata_from_transforms(order: Literal["C", "F"], name: Optional[str]):
+    units = ("nm",) * 3
+    axes = ("z", "y", "x")
+    scale = (3, 2, 1)
+
+    if order == "C":
+        reorder = slice(None, None, -1)
+    else:
+        reorder = slice(0, None, 1)
+
+    transforms = {}
+    transforms["s0"] = STTransform(
+        order=order, scale=scale, translate=(1,) * 3, units=("nm",) * 3, axes=axes
+    )
+    transforms["s1"] = transforms["s0"].model_copy(
+        deep=True,
+        update={
+            "scale": list(2 * s for s in scale),
+            "translate": [
+                1.5,
+            ]
+            * 3,
+        },
+    )
+
+    expected = GroupMetadata(
+        axes=axes[reorder],
+        scales=[[1, 1, 1], [2, 2, 2]],
+        units=units[reorder],
+        pixelResolution=PixelResolution(unit=units[reorder][0], dimensions=scale[reorder]),
+        multiscales=[MultiscaleMetadata.from_transforms(transforms, name=name)],
+    )
+
+    observed = GroupMetadata.from_transforms(transforms, name=name)
+    assert expected == observed
+
+
 @pytest.mark.parametrize("order", ("C", "F"))
 def test_multiscale_array_c_f_order(order: Literal["C", "F"]):
     transform = STTransform(
@@ -163,3 +248,157 @@ def test_multiscale_group(
         attrs["axes"] = attrs["axes"][::-1]
         with pytest.raises(ValidationError):
             Group(members=members_dict, attributes=attrs)
+
+
+@pytest.mark.parametrize("name", [None, "bar"])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_multiscale_group_from_arrays(order: Literal["C", "F"], name: Optional[str]):
+    units = ("nm",) * 3
+    axes = ("z", "y", "x")
+    scale = (3, 2, 1)
+
+    if order == "C":
+        reorder = slice(None, None, -1)
+    else:
+        reorder = slice(0, None, 1)
+
+    transforms = {
+        "s0": STTransform(order=order, scale=scale, translate=(1,) * 3, units=units, axes=axes),
+        "s1": STTransform(
+            order=order,
+            scale=tuple(2 * s for s in scale),
+            translate=(1.5,) * 3,
+            units=units,
+            axes=axes,
+        ),
+    }
+
+    arrays = {
+        "s0": Array.from_array(
+            np.zeros((10, 10, 10)), attributes=ArrayMetadata.from_transform(transforms["s0"])
+        ),
+        "s1": Array.from_array(
+            np.zeros((5, 5, 5)), attributes=ArrayMetadata.from_transform(transforms["s1"])
+        ),
+    }
+
+    groupMeta = GroupMetadata(
+        axes=axes[reorder],
+        scales=[[1, 1, 1], [2, 2, 2]],
+        units=units[reorder],
+        pixelResolution=PixelResolution(unit=units[reorder][0], dimensions=scale[reorder]),
+        multiscales=[MultiscaleMetadata.from_transforms(transforms)],
+    )
+
+    expected = Group(attributes=groupMeta, members=arrays)
+    observed = Group.from_arrays(arrays)
+    assert expected == observed
+
+
+@pytest.mark.parametrize("axes", [None, ("z", "y", "x")])
+@pytest.mark.parametrize(
+    "translate",
+    [
+        None,
+        (0, 1, 2),
+    ],
+)
+@pytest.mark.parametrize(
+    "scale",
+    [
+        None,
+        (1, 2, 3),
+    ],
+)
+@pytest.mark.parametrize("units", [None, ("m", "m", "m")])
+@pytest.mark.parametrize("order", [None, "C", "F"])
+def test_change_coordinates_3d(
+    axes: Optional[str],
+    translate: Optional[tuple[int, ...]],
+    scale: Optional[tuple[int, ...]],
+    units: Optional[tuple[str, ...]],
+    order: Optional[Literal["C", "F"]],
+):
+    base_units_c = ("micron", "micron", "micron")
+    base_axes_c = ("a", "b", "c")
+    base_scale_c = (4, 5, 6)
+    base_translate_c = (-1, -2, -3)
+    base_order = "C"
+
+    if axes is None:
+        axes_expected = base_axes_c
+    else:
+        axes_expected = axes
+
+    if scale is None:
+        scale_expected = base_scale_c
+    else:
+        scale_expected = scale
+
+    if translate is None:
+        translate_expected = base_translate_c
+    else:
+        translate_expected = translate
+
+    if units is None:
+        units_expected = base_units_c
+    else:
+        units_expected = units
+
+    if order is None:
+        order_expected = base_order
+    else:
+        order_expected = order
+
+    tx_s0_expected = STTransform(
+        order=order_expected,
+        scale=scale_expected,
+        translate=translate_expected,
+        units=units_expected,
+        axes=axes_expected,
+    )
+
+    tx_s1_expected = tx_s0_expected.model_copy(
+        deep=True,
+        update={
+            "scale": tuple(2 * x for x in tx_s0_expected.scale),
+            "translate": tuple(x + 0.5 for x in tx_s0_expected.translate),
+        },
+    )
+
+    transforms_expected = {"s0": tx_s0_expected, "s1": tx_s1_expected}
+
+    arrays = {
+        "s0": Array.from_array(
+            np.zeros((10, 10, 10)),
+            attributes=ArrayMetadata.from_transform(transforms_expected["s0"]),
+        ),
+        "s1": Array.from_array(
+            np.zeros((5, 5, 5)), attributes=ArrayMetadata.from_transform(transforms_expected["s1"])
+        ),
+    }
+
+    source_spec = Group.from_arrays(arrays)
+
+    new_spec = change_coordinates(
+        source_spec, axes=axes, order=order, translate=translate, scale=scale, units=units
+    )
+    new_attrs = new_spec.attributes
+
+    if order in ("C", None):
+        reorder = slice(None, None, -1)
+    else:
+        reorder = slice(0, None, 1)
+
+    assert new_attrs.axes == axes_expected[reorder]
+    assert new_attrs.pixelResolution.dimensions == scale_expected[reorder]
+    assert new_attrs.pixelResolution.unit == units_expected[reorder][0]
+    assert new_attrs.scales == source_spec.attributes.scales
+    assert new_attrs.multiscales[0].datasets[0] == ScaleMetadata(
+        path="s0", transform=transforms_expected["s0"]
+    )
+    assert new_attrs.multiscales[0].datasets[1] == ScaleMetadata(
+        path="s1", transform=transforms_expected["s1"]
+    )
+    assert new_spec.members["s0"].attributes.transform == transforms_expected["s0"]
+    assert new_spec.members["s1"].attributes.transform == transforms_expected["s1"]

--- a/tests/test_n5.py
+++ b/tests/test_n5.py
@@ -1,0 +1,39 @@
+import zarr
+from numcodecs import GZip
+from pydantic_zarr.v2 import GroupSpec
+
+from cellmap_schemas.n5_wrap import n5_array_unwrapper, n5_spec_unwrapper, n5_spec_wrapper
+
+
+def test_n5_wrapping(tmpdir: str) -> None:
+    n5_store = zarr.N5FSStore(str(tmpdir))
+    group = zarr.group(n5_store, path="group1")
+    group.attrs.put({"group": "true"})
+    compressor = GZip(-1)
+    arr = group.create_dataset(
+        name="array", shape=(10, 10, 10), compressor=compressor, dimension_separator="."
+    )
+    arr.attrs.put({"array": True})
+
+    spec_n5 = GroupSpec.from_zarr(group)
+    assert spec_n5.members["array"].dimension_separator == "."
+
+    arr_unwrapped = n5_array_unwrapper(spec_n5.members["array"])
+
+    assert arr_unwrapped.dimension_separator == "/"
+    assert arr_unwrapped.compressor == compressor.get_config()
+
+    spec_unwrapped = n5_spec_unwrapper(spec_n5)
+    assert spec_unwrapped.attributes == spec_n5.attributes
+    assert spec_unwrapped.members["array"] == arr_unwrapped
+
+    spec_wrapped = n5_spec_wrapper(spec_unwrapped)
+    group2 = spec_wrapped.to_zarr(group.store, path="group2")
+    assert GroupSpec.from_zarr(group2) == spec_n5
+
+    """     
+    # test with N5 metadata
+    test_data = np.zeros((10, 10, 10))
+    multi = multiscale(test_data, windowed_mean, (2, 2, 2))
+    n5_neuroglancer_spec = NeuroglancerN5Group.from_xarrays(multi, chunks="auto")
+    assert n5_spec_wrapper(n5_neuroglancer_spec) """


### PR DESCRIPTION
- added `N5Group`, which is a groupspec with special handling of `to_zarr` / `from_zarr` that a) ensures that only `zarr.N5FSStore` is used as the backing store, and b) removes the zarr-python` wrapping from codec metadata.
- added routines for changing the `scale` , `axes`, `translate`, `order`, and `units` of a `multiscale.cosem.Group`. This required adding new classmethods for the underlying group metadata for creating metadata classes from dicts of `Array` or dicts of `STTransform`. 
