### PR TITLE
support for python 3.9

### DIFF
--- a/src/cellmap_schemas/base.py
+++ b/src/cellmap_schemas/base.py
@@ -1,8 +1,5 @@
+from __future__ import annotations
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
-
-
-def structure_array_equal(spec_a: ArraySpec, spec_b: ArraySpec) -> bool:
-    return spec_a.model_dump(exclude=["attributes"]) == spec_b.model_dump(exclude=["attributes"])
 
 
 def structure_group_equal(spec_a: GroupSpec, spec_b: GroupSpec) -> bool:
@@ -10,7 +7,7 @@ def structure_group_equal(spec_a: GroupSpec, spec_b: GroupSpec) -> bool:
     if keys_equal:
         for member_a, member_b in zip(spec_a.members.values(), spec_b.members.values()):
             if isinstance(member_a, ArraySpec):
-                member_eq = structure_array_equal(member_a, member_b)
+                member_eq = member_a.like(member_b, exclude={"attributes"})
             else:
                 member_eq = structure_group_equal(member_a, member_b)
             if member_eq is False:
@@ -31,7 +28,7 @@ def structure_equal(spec_a: ArraySpec | GroupSpec, spec_b: ArraySpec | GroupSpec
             f"Cannot apply this function to objects with types ({type(spec_a)}, {type(spec_b)})"
         )
     if isinstance(spec_a, ArraySpec) and isinstance(spec_b, ArraySpec):
-        return structure_array_equal(spec_a, spec_b)
+        return spec_a.like(spec_b, exclude="attributes")
     elif isinstance(spec_a, GroupSpec) and isinstance(spec_b, GroupSpec):
         return structure_group_equal(spec_a, spec_b)
     else:

--- a/src/cellmap_schemas/cli.py
+++ b/src/cellmap_schemas/cli.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Any, Literal, Tuple, Union, cast
 import click
 from pydantic_zarr.v2 import ArraySpec, GroupSpec, from_zarr

--- a/src/cellmap_schemas/multiscale/cosem.py
+++ b/src/cellmap_schemas/multiscale/cosem.py
@@ -492,19 +492,15 @@ def change_coordinates(
         base_transform, scale=scale, axes=axes, order=order, translate=translate, units=units
     )
     # if we started at 4 and end up at 8, then the scale_diff should be 2
-    scale_diff = [
-        a / b for a, b in zip(new_base_transform.scale, base_transform.scale, strict=True)
-    ]
+    scale_diff = [a / b for a, b in zip(new_base_transform.scale, base_transform.scale)]
     # if we started at 0 and we are moved to 10, then the translation_diff should be +10
-    translate_diff = [
-        a - b for a, b in zip(new_base_transform.translate, base_transform.translate, strict=True)
-    ]
+    translate_diff = [a - b for a, b in zip(new_base_transform.translate, base_transform.translate)]
     new_transforms = {}
 
     for key, member in members_sorted.items():
         old_tx = member.attributes.transform
-        new_scale = [a * b for a, b in zip(old_tx.scale, scale_diff, strict=True)]
-        new_trans = [a + b for a, b in zip(old_tx.translate, translate_diff, strict=True)]
+        new_scale = [a * b for a, b in zip(old_tx.scale, scale_diff)]
+        new_trans = [a + b for a, b in zip(old_tx.translate, translate_diff)]
         new_transforms[key] = new_sttransform(
             old_tx, scale=new_scale, translate=new_trans, order=order, units=units, axes=axes
         )

--- a/src/cellmap_schemas/multiscale/cosem.py
+++ b/src/cellmap_schemas/multiscale/cosem.py
@@ -6,7 +6,7 @@ that's compatible with the [Neuroglancer](https://github.com/google/neuroglancer
 Note that the hierarchy convention modeled here will likely be superceded by conventions defined
 in the [OME-NGFF](https://ngff.openmicroscopy.org/) specification.
 """
-
+from __future__ import annotations
 from typing import Annotated, Dict, List, Literal, Optional, Sequence, Tuple
 import numpy as np
 from pydantic_zarr.v2 import GroupSpec, ArraySpec

--- a/src/cellmap_schemas/multiscale/neuroglancer_n5.py
+++ b/src/cellmap_schemas/multiscale/neuroglancer_n5.py
@@ -3,7 +3,7 @@ This module contains Pydantic models for Neuroglancer-compatible multiscale imag
 in N5 groups. See Neuroglancer's [N5-specific documentation](https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/n5) 
 for details on what Neuroglancer expects when it reads N5 data.
 """
-
+from __future__ import annotations
 from typing import Annotated, Sequence
 from pydantic import BaseModel, PositiveInt, model_validator, AfterValidator
 from pydantic_zarr.v2 import ArraySpec

--- a/src/cellmap_schemas/n5_wrap.py
+++ b/src/cellmap_schemas/n5_wrap.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 from typing import overload, Union
 

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Literal
 
 import pytest

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from cellmap_schemas.base import structure_equal
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from cellmap_schemas.cli import parse_url
 import pytest
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 from pytest_examples import find_examples, CodeExample, EvalExample
 

--- a/tests/test_multiscale/test_cosem.py
+++ b/tests/test_multiscale/test_cosem.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import reduce
 import operator
 from typing import Literal, Optional, Tuple

--- a/tests/test_multiscale/test_neuroglancer_n5.py
+++ b/tests/test_multiscale/test_neuroglancer_n5.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Optional
 from pydantic import ValidationError
 import pytest

--- a/tests/test_n5.py
+++ b/tests/test_n5.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import zarr
 from numcodecs import GZip
 from pydantic_zarr.v2 import GroupSpec


### PR DESCRIPTION
- removes some pre-python 3.10 stuff
- `from __future__ import annotations`
- drive-by usage of some newer pydantic-zarr functionality